### PR TITLE
Moving to oauth2-proxy v.7.0.1

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -18,8 +18,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: v6.1.1
+appVersion: v7.0.1


### PR DESCRIPTION
I tested this new version of oauth2-proxy on k8s v1.18.10 with a Keycloak (v11) OIDC auth code flow and all is working well. Want to get this into the saturnwire helm repo so it's available for deployment use.