### PR TITLE
oauth2_proxy app version bump

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -19,8 +19,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: v7.0.1
+appVersion: v7.1.3


### PR DESCRIPTION
Bumping oauth2_proxy app version in chart from v7.0.1 to v7.1.3.

There's a [new feature](https://github.com/oauth2-proxy/oauth2-proxy/pull/980) in 7.1.0 that adds a /metrics endpoint for Prometheus scraping, but they're still squashing bugs and it doesn't look completely baked yet, so I think we should give it some more time before we add a config option to this chart.